### PR TITLE
Added -aa option to unzip command which forces any file in the archiv…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ $(TOKEN_EXTRACTED_SCHEMATRON): $(ISO_SCHEMATRON_XSLT2_ZIP) $(TOKEN_CHECKSUMS_OK)
 	rm -rf pkg/iso-schematron-xslt2
 	rm -f $(TOKEN_PATCHED_SCHEMATRON)
 	mkdir -p pkg/iso-schematron-xslt2
-	unzip -d pkg/iso-schematron-xslt2 $<
+	unzip -aa -d pkg/iso-schematron-xslt2 $<
 	mkdir -p $(dir $@)
 	touch $@
 


### PR DESCRIPTION
…e to have host system new line characters after extraction. This fixes "different line endings" error when patching but has only been tested on Windows 8 using Cygwin 6.3.2.2.
